### PR TITLE
setup proper paths for gtk pixbuf

### DIFF
--- a/gtk-launch
+++ b/gtk-launch
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+if [ "$SNAP_ARCH" == "amd64" ]; then
+  ARCH="x86_64-linux-gnu"
+elif [ "$SNAP_ARCH" == "armhf" ]; then
+  ARCH="arm-linux-gnueabihf"
+elif [ "$SNAP_ARCH" == "arm64" ]; then
+  ARCH="aarch64-linux-gnu"
+else
+  ARCH="$SNAP_ARCH-linux-gnu"
+fi
+
+export XDG_CACHE_HOME="$SNAP_USER_COMMON/.cache"
+mkdir -p "$XDG_CACHE_HOME"
+
+# Gdk-pixbuf loaders
+export GDK_PIXBUF_MODULE_FILE="$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache"
+export GDK_PIXBUF_MODULEDIR="$SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders"
+if [ -f "$SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders" ]; then
+  "$SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders" > "$GDK_PIXBUF_MODULE_FILE"
+fi
+
+exec "$@"

--- a/gtk-launch
+++ b/gtk-launch
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-if [ "$SNAP_ARCH" == "amd64" ]; then
+if [ "$SNAP_ARCH" = "amd64" ]; then
   ARCH="x86_64-linux-gnu"
-elif [ "$SNAP_ARCH" == "armhf" ]; then
+elif [ "$SNAP_ARCH" = "armhf" ]; then
   ARCH="arm-linux-gnueabihf"
-elif [ "$SNAP_ARCH" == "arm64" ]; then
+elif [ "$SNAP_ARCH" = "arm64" ]; then
   ARCH="aarch64-linux-gnu"
 else
   ARCH="$SNAP_ARCH-linux-gnu"

--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -25,8 +25,13 @@ license: GPL-3.0+
 
 apps:
   emacs:
+    command-chain:
+      - gtk-launch
     command: usr/bin/emacs
     desktop: usr/share/applications/emacs.desktop
+    # Required until Snapcraft 3.9
+    # https://github.com/snapcore/snapcraft/pull/2686
+    adapter: full
   emacsclient:
     command: usr/bin/emacsclient
   ctags:
@@ -155,3 +160,8 @@ parts:
       snapcraftctl prime
       # Fix-up application icon lookup
       sed -i.bak -e 's|^Icon=.*|Icon=usr/share/icons/hicolor/scalable/apps/emacs.svg|g' usr/share/applications/emacs.desktop
+  command-chain:
+    source: .
+    plugin: dump
+    stage:
+      - gtk-launch


### PR DESCRIPTION
Achieve this by use of command-chain and getting rid of the
wrappers.

Fixes #3

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>