### PR TITLE
avoid export XDG_CACHE_HOME

### DIFF
--- a/setup-env
+++ b/setup-env
@@ -10,11 +10,11 @@ else
   ARCH="$SNAP_ARCH-linux-gnu"
 fi
 
-export XDG_CACHE_HOME="$SNAP_USER_COMMON/.cache"
-mkdir -p "$XDG_CACHE_HOME"
+GDK_CACHE_DIR="$SNAP_USER_COMMON/.cache"
+[ ! -d "$GDK_CACHE_DIR" ] && mkdir -p "$GDK_CACHE_DIR"
 
 # Gdk-pixbuf loaders
-export GDK_PIXBUF_MODULE_FILE="$XDG_CACHE_HOME/gdk-pixbuf-loaders.cache"
+export GDK_PIXBUF_MODULE_FILE="$GDK_CACHE_DIR/gdk-pixbuf-loaders.cache"
 export GDK_PIXBUF_MODULEDIR="$SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/2.10.0/loaders"
 if [ -f "$SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders" ]; then
   "$SNAP/usr/lib/$ARCH/gdk-pixbuf-2.0/gdk-pixbuf-query-loaders" > "$GDK_PIXBUF_MODULE_FILE"


### PR DESCRIPTION
Exporting XDG_CACHE_HOME affects applications launched from within
the context of emacs.

Rename it to GDK_CACHE_DIR and do not export it. Also test for
existence before creating to avoid shelling out to mkdir if not
needed.

Signed-off-by: Sergio Schvezov <sergio.schvezov@canonical.com>