### PR TITLE
Update to latest upstream release "29.4"

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -51,8 +51,8 @@ parts:
   emacs:
     after: [tree-sitter]
     plugin: nil
-    source: https://mirrors.ocf.berkeley.edu/gnu/emacs/emacs-29.3.tar.xz
-    source-checksum: sha256/c34c05d3ace666ed9c7f7a0faf070fea3217ff1910d004499bd5453233d742a0
+    source: https://mirrors.ocf.berkeley.edu/gnu/emacs/emacs-29.4.tar.xz
+    source-checksum: sha256/ba897946f94c36600a7e7bb3501d27aa4112d791bfe1445c61ed28550daca235
     organize:
       snap/emacs/current/usr: usr
     build-packages:


### PR DESCRIPTION
> Emacs 29.4 is an emergency bugfix release; it includes no new features except a small number of changes intended to resolve a security vulnerability uncovered in Emacs 29.3 and earlier.

- https://lists.gnu.org/archive/html/emacs-devel/2024-06/msg00695.html

@alexmurray Would be good to release this soon as it fixes a vulnerability in the built-in org-mode, see https://list.orgmode.org/87sex5gdqc.fsf@localhost/T/#u