### PR TITLE
many: add spread test execution to CI via image-garden

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    outputs:
+      systems: ${{ steps.systems.outputs.systems }}
     steps:
     - uses: actions/checkout@v3
     - uses: snapcore/action-build@v1
@@ -15,6 +17,22 @@ jobs:
       with:
         name: emacs-snap
         path: ${{ steps.build.outputs.snap }}
+    - id: systems
+      name: Read the garden backend's system list out of spread.yaml
+      # spread.yaml is the single source of truth for which systems we test
+      # - extract its backends.garden.systems list (each entry is a one-key
+      # "- system-name:" mapping) as a JSON array for the spread job's
+      # matrix below, rather than hand-duplicating the list here where it
+      # can silently drift out of sync (as happened with an earlier rename
+      # of one of these system names). grep+jq rather than a YAML parser:
+      # avoids needing to know whether PyYAML is preinstalled (it can hit
+      # PEP 668's "externally-managed-environment" restriction if not) or
+      # which of the two incompatible tools named "yq" (if either) is on
+      # PATH - both grep -P and jq are always present on GitHub's runners.
+      run: |
+        systems=$(grep -oP '^\s+-\s+\K[a-zA-Z0-9._-]+(?=:\s*$)' spread.yaml \
+          | jq -R -s -c 'split("\n") | map(select(length > 0))')
+        echo "systems=$systems" >> "$GITHUB_OUTPUT"
 
   spread:
     runs-on: ubuntu-latest
@@ -22,30 +40,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        system: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
+        system: ${{ fromJSON(needs.build.outputs.systems) }}
     steps:
     - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
     - uses: actions/download-artifact@v4
       with:
         name: emacs-snap
-    - uses: actions/setup-go@v5
-      with:
-        go-version: stable
-    - name: Install spread
-      run: go install github.com/canonical/spread/cmd/spread@latest
-    - name: Set up LXD
-      run: |
-        sudo groupadd --force lxd
-        sudo usermod --append --groups lxd "$USER"
-        sudo snap install lxd
-        sudo lxd waitready
-        sudo lxd init --auto
-        # Docker (preinstalled on the runner) sets the FORWARD chain policy
-        # to DROP, which silently kills outbound traffic from lxdbr0 since
-        # it isn't Docker's own bridge; reopen it so containers can reach
-        # the network.
-        sudo iptables -P FORWARD ACCEPT
     - name: Run spread tests (local channel only)
-      # sg is needed since the lxd group membership above only takes effect
-      # in a new login session, not this already-running shell
-      run: sg lxd -c "$(go env GOPATH)/bin/spread -v lxd:${{ matrix.system }}:tests/...:local"
+      uses: zyga/image-garden-action@v0
+      with:
+        garden-system: ${{ matrix.system }}
+        spread-tasks: tests/...:local

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,3 +10,42 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - uses: snapcore/action-build@v1
+      id: build
+    - uses: actions/upload-artifact@v4
+      with:
+        name: emacs-snap
+        path: ${{ steps.build.outputs.snap }}
+
+  spread:
+    runs-on: ubuntu-latest
+    needs: build
+    strategy:
+      fail-fast: false
+      matrix:
+        system: [ubuntu-22.04, ubuntu-24.04, ubuntu-26.04]
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v4
+      with:
+        name: emacs-snap
+    - uses: actions/setup-go@v5
+      with:
+        go-version: stable
+    - name: Install spread
+      run: go install github.com/canonical/spread/cmd/spread@latest
+    - name: Set up LXD
+      run: |
+        sudo groupadd --force lxd
+        sudo usermod --append --groups lxd "$USER"
+        sudo snap install lxd
+        sudo lxd waitready
+        sudo lxd init --auto
+        # Docker (preinstalled on the runner) sets the FORWARD chain policy
+        # to DROP, which silently kills outbound traffic from lxdbr0 since
+        # it isn't Docker's own bridge; reopen it so containers can reach
+        # the network.
+        sudo iptables -P FORWARD ACCEPT
+    - name: Run spread tests (local channel only)
+      # sg is needed since the lxd group membership above only takes effect
+      # in a new login session, not this already-running shell
+      run: sg lxd -c "$(go env GOPATH)/bin/spread -v lxd:${{ matrix.system }}:tests/...:local"

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,18 @@
 /*.snap
+
+# image-garden(1) generated VM images/state and spread's own resume
+# bookkeeping, left behind by `spread garden:...` runs from the repo root
+/.image-garden/
+/.spread-reuse*.yaml
+/*.qcow2
+/*.run
+/*.seed.iso
+/*.user-data
+/*.meta-data
+/*.lock
+/*.serial.log
+/*.stdout.log
+/*.stderr.log
+/*.qcow2.log
+/efi-code.*.img
+/efi-vars.*.img

--- a/.image-garden.mk
+++ b/.image-garden.mk
@@ -1,0 +1,9 @@
+# Required to exist by zyga/image-garden-action (github.com/zyga/image-
+# garden-action) - its "Restore mtime of .image-garden.mk" step
+# unconditionally runs `git restore-mtime .image-garden.mk` and its VM-image
+# cache key is `hashFiles('.image-garden.mk')`, so a missing file breaks the
+# whole job even though image-garden itself only needs this file for
+# project-specific customization (see image-garden(1)), which we don't need:
+# all our systems (spread.yaml's backends.garden.systems) are stock
+# image-garden cloud images, and package installation happens in
+# spread.yaml's own prepare: scripts rather than cloud-init templates.

--- a/spread.yaml
+++ b/spread.yaml
@@ -1,69 +1,63 @@
 project: emacs-snap
 
 backends:
-  qemu:
+  # spread integration for image-garden(1) (https://gitlab.com/zygoon/image-garden)
+  # - a single backend for both local dev and CI (github.com/zyga/image-
+  # garden-action). It downloads and caches official cloud images and boots
+  # them under real QEMU/KVM, so unlike the lxd container backend this
+  # replaced, there's no nested AppArmor policy namespace to trip over (see
+  # git history on tests/setup-env/task.yaml for what that cost us) and,
+  # unlike the old qemu backend, no manual image-baking either. Needs the
+  # image-garden snap (`snap install image-garden`) and /dev/kvm access -
+  # GitHub's standard hosted runners have both.
+  garden:
+    type: adhoc
+    allocate: |
+      if [ -n "${SPREAD_HOST_PATH-}" ]; then
+        PATH="${SPREAD_HOST_PATH}"
+      fi
+      exec image-garden allocate --spread "$SPREAD_SYSTEM"."$(uname -m)"
+    discard: |
+      if [ -n "${SPREAD_HOST_PATH-}" ]; then
+        PATH="${SPREAD_HOST_PATH}"
+      fi
+      exec image-garden discard "$SPREAD_SYSTEM_ADDRESS"
     systems:
-      # build via autopkgtest-buildvm-ubuntu-cloud and mv to ~/.spread/qemu/
-      - ubuntu-18.04-64:
+      - ubuntu-cloud-18.04:
           username: ubuntu
           password: ubuntu
-      - ubuntu-20.04-64:
+      - ubuntu-cloud-20.04:
           username: ubuntu
           password: ubuntu
-      - ubuntu-22.04-64:
+      - ubuntu-cloud-22.04:
           username: ubuntu
           password: ubuntu
-      - ubuntu-24.04-64:
+      - ubuntu-cloud-24.04:
           username: ubuntu
           password: ubuntu
-      - ubuntu-26.04-64:
+      - ubuntu-cloud-26.04:
           username: ubuntu
           password: ubuntu
 
-      # build an image as per
-      # https://blog.strandboge.com/2019/04/16/cloud-images-qemu-cloud-init-and-snapd-spread-tests/
-      - centos-8-64:
+      # centos-cloud-8 and rocky-cloud-8 aren't offered any more (both EOL)
+      # - standardised on the 9 stream for both rather than mixing families
+      - centos-cloud-9:
           username: centos
           password: centos
-      # also build as per jdstrand's blog post but using image from
-      # https://dl.rockylinux.org/pub/rocky/8/images/x86_64/
-      # wget https://dl.rockylinux.org/pub/rocky/8/images/x86_64/Rocky-8-GenericCloud.latest.x86_64.qcow2
-      # #cp instead of mv so we can try again if we mess it up
-      # cp Rocky-8-GenericCloud.latest.x86_64.qcow2 rockylinux-8-64.img
-      # qemu-img resize rockylinux-8-64.img 20G
-      # cat <<EOF>rockylinux-data
-      # #cloud-config
-      # password: rocky
-      # chpasswd: { expire: false }
-      # ssh_pwauth: true
-      # EOF
-      # cat <<EOF>rockylinux-meta-data
-      # instance-id: i-rockylinux-8-64
-      # local-hostname: rockylinux-8-64
-      # EOF
-      # cloud-localds -v ./rockylinux-seed.img ./rockylinux-data ./rockylinux-meta-data
-      # kvm -M pc -m 1024 -smp 1 -monitor pty -nographic -hda ./rockylinux-8-64.img -drive "file=./rockylinux-seed.img,if=virtio,format=raw" -net nic -net user,hostfwd=tcp:127.0.0.1:59355-:22
-      #
-      # wait for it to boot and finish configuring via cloud-init then in another terminal
-      # ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 59355 rocky@127.0.0.1 sudo touch /etc/cloud/cloud-init.disabled
-      # ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -p 59355 rocky@127.0.0.1 sudo shutdown -h now
-      # mv rockylinux-8-64.img ~/.spread/qemu/
-      - rockylinux-8-64:
+      - rocky-cloud-9:
           username: rocky
           password: rocky
 
-  # lightweight backend for CI (github.com/actions): no image-baking needed,
-  # spread resolves e.g. "ubuntu-24.04" straight to the official
-  # ubuntu:24.04/amd64 LXD image, and containers don't need KVM/nested
-  # virtualization like the qemu backend does. Only covers the CHANNEL/local
-  # suite (see .github/workflows/main.yml) since there's no snap store
-  # network access assumed in CI. Systems are the top 3 by install-base
-  # share per the snap store metrics (~84% combined: 24.04/22.04/26.04).
-  lxd:
-    systems:
-      - ubuntu-22.04
-      - ubuntu-24.04
-      - ubuntu-26.04
+      # per install-base share, Debian is the only non-Ubuntu-derived distro
+      # with meaningful usage that isn't already covered above (Mint, Pop,
+      # Zorin etc are all Ubuntu derivatives, closely proxied by testing
+      # real Ubuntu)
+      - debian-cloud-12:
+          username: debian
+          password: debian
+      - debian-cloud-13:
+          username: debian
+          password: debian
 
 path: /spread/emacs-snap
 
@@ -91,7 +85,7 @@ suites:
     summary: spread tests
     prepare: |
       case $SPREAD_SYSTEM in
-        centos-*|rockylinux-*)
+        centos-*|rocky-*)
           if [ $SPREAD_REBOOT = 0 ]; then
             # disable SELinux since otherwise snapd can't seem to talk to store
             sed -i 's/SELINUX=enforcing/SELINUX=disabled/' /etc/selinux/config
@@ -106,7 +100,7 @@ suites:
           ln -sf /var/lib/snapd/snap /snap
           snap wait system seed.loaded
           ;;
-        ubuntu-*)
+        ubuntu-*|debian-*)
           # ensure machine is up to date
           export DEBIAN_FRONTEND=noninteractive
           # use apt-get to support older Ubuntu releases
@@ -126,7 +120,18 @@ suites:
       if [ $CHANNEL == local ]; then
         snap install --classic --dangerous $SPREAD_PATH/emacs_*.snap
       else
-        snap install --classic --channel $CHANNEL emacs
+        # store-channel installs occasionally hit a transient
+        # store-communication error (e.g. a request racing snapd's own
+        # "waiting for automatic snapd restart" post-install handoff) -
+        # retry a few times rather than failing the whole task on a blip.
+        n=0
+        until snap install --classic --channel $CHANNEL emacs; do
+          n=$((n + 1))
+          if [ $n -ge 3 ]; then
+            exit 1
+          fi
+          sleep 10
+        done
       fi
 
     restore-each: |

--- a/spread.yaml
+++ b/spread.yaml
@@ -52,6 +52,19 @@ backends:
           username: rocky
           password: rocky
 
+  # lightweight backend for CI (github.com/actions): no image-baking needed,
+  # spread resolves e.g. "ubuntu-24.04" straight to the official
+  # ubuntu:24.04/amd64 LXD image, and containers don't need KVM/nested
+  # virtualization like the qemu backend does. Only covers the CHANNEL/local
+  # suite (see .github/workflows/main.yml) since there's no snap store
+  # network access assumed in CI. Systems are the top 3 by install-base
+  # share per the snap store metrics (~84% combined: 24.04/22.04/26.04).
+  lxd:
+    systems:
+      - ubuntu-22.04
+      - ubuntu-24.04
+      - ubuntu-26.04
+
 path: /spread/emacs-snap
 
 exclude:

--- a/spread.yaml
+++ b/spread.yaml
@@ -117,7 +117,7 @@ suites:
       esac
 
     prepare-each: |
-      if [ $CHANNEL == local ]; then
+      if [ "$CHANNEL" = local ]; then
         snap install --classic --dangerous $SPREAD_PATH/emacs_*.snap
       else
         # store-channel installs occasionally hit a transient

--- a/tests/host-libraries/task.yaml
+++ b/tests/host-libraries/task.yaml
@@ -12,10 +12,10 @@ prepare: |
   # environment isn't artificially font-starved in a way no real user's
   # desktop would be.
   case $SPREAD_SYSTEM in
-    centos-*|rockylinux-*)
+    centos-*|rocky-*)
       dnf install -y xorg-x11-server-Xvfb dejavu-sans-fonts
       ;;
-    ubuntu-*)
+    ubuntu-*|debian-*)
       apt install -y xvfb fonts-dejavu-core
       ;;
   esac

--- a/tests/setup-env/task.yaml
+++ b/tests/setup-env/task.yaml
@@ -12,46 +12,6 @@ prepare: |
   # - if the store is unreachable, that check just skips cleanly
   snap install yq || true
 
-  # Work around LP#1815869: snap-confine's own AppArmor profile has no way to
-  # delegate an inherited file descriptor's permission check to the eventual
-  # per-app profile, so revalidating an inherited fd (eg a shell redirect
-  # like `yq < file.yml`) against snap-confine's own narrow profile can fail
-  # even for files the invoking user plainly owns. This is normally masked by
-  # the kernel's aa_file_perm() fast path for genuinely unconfined callers,
-  # but that fast path is skipped once a process has triggered Ubuntu's
-  # unprivileged_userns AppArmor profile stacking (eg via
-  # unshare(CLONE_NEWUSER)) - which every process inside an unprivileged LXD
-  # container has, inherited from the container's own init onward, which is
-  # why the lxd backend trips this and qemu's real VMs don't.
-  if [ "$SPREAD_BACKEND" = lxd ] && [[ "$SPREAD_SYSTEM" == ubuntu-* ]]; then
-    # Grant the same owner-scoped access snap-confine already carries for our
-    # test fixture's use of /tmp so inherited fds for files the invoking user
-    # owns are honoured consistently regardless of which fast path applies.
-    #
-    # Both the deb-packaged profile (confining /usr/lib/snapd/snap-confine) and
-    # the snapd-snap-bundled one (confining
-    # /snap/snapd/<rev>/usr/lib/snapd/snap-confine) #include a snapd-managed
-    # directory wholesale - any file dropped in there becomes part of the
-    # compiled profile automatically, the same way each one's existing "cap-bpf"
-    # file already does. That directory's name is snapd-version- specific and
-    # not safe to hardcode: it's "snap-confine" on snapd 2.76.3+ubuntu24.04, but
-    # was renamed to "snap-confine.internal" by snapd 2.76.3+ubuntu26.04 (both
-    # otherwise report the same "snap version" output, so the name alone doesn't
-    # tell you which one a given system uses) - so read the real #include target
-    # out of each profile source instead of guessing it.
-    for src in /etc/apparmor.d/usr.lib.snapd.snap-confine.real /var/lib/snapd/apparmor/profiles/snap-confine.snapd.*; do
-      [ -f "$src" ] || continue
-      inc=$(sed -n 's/.*#include "\(\/var\/lib\/snapd\/apparmor\/[^"]*\)".*/\1/p' "$src" | head -1)
-      if [ -n "$inc" ] && [ -d "$inc" ]; then
-        printf 'owner /tmp/** rw,\n' > "$inc/zz-fd-inherit-workaround"
-      fi
-    done
-    # Restart both services which manage these profiles since which of the two
-    # profiles above is the one that actually matters isn't guaranteed to be the
-    # same on every system.
-    systemctl restart snapd.apparmor.service apparmor.service 2>/dev/null || true
-  fi
-
 restore: |
   if [ -f /usr/share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml.bak ]; then
     mv /usr/share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml.bak /usr/share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml
@@ -62,18 +22,6 @@ restore: |
   pkill -x emacs 2>/dev/null || true
   rm -f /tmp/emacs-apparmor.log /tmp/emacs-snap-fd-test.yml
   snap remove yq 2>/dev/null || true
-
-  # undo the LP#1815869 workaround from prepare - same dynamic #include
-  # discovery as prepare, since the target directory name is snapd-version-
-  # specific (see prepare for why)
-  for src in /etc/apparmor.d/usr.lib.snapd.snap-confine.real /var/lib/snapd/apparmor/profiles/snap-confine.snapd.*; do
-    [ -f "$src" ] || continue
-    inc=$(sed -n 's/.*#include "\(\/var\/lib\/snapd\/apparmor\/[^"]*\)".*/\1/p' "$src" | head -1)
-    if [ -n "$inc" ] && [ -f "$inc/zz-fd-inherit-workaround" ]; then
-      rm -f "$inc/zz-fd-inherit-workaround"
-    fi
-  done
-  systemctl restart snapd.apparmor.service apparmor.service 2>/dev/null || true
 
 execute: |
   ! test -d ~/snap/emacs/common/.cache/schemas

--- a/tests/setup-env/task.yaml
+++ b/tests/setup-env/task.yaml
@@ -137,8 +137,21 @@ execute: |
         # unrelated host-installed yq (eg python's, via apt/pip) that would
         # silently pass this check without ever going through snap-confine
         # at all.
+        #
+        # Confirmed (2026-09-09) by running this exact task side-by-side on
+        # the same host under both backends: it fails identically under lxd
+        # but passes under qemu. lxd containers get a nested AppArmor
+        # namespace stacked on the host kernel's, unlike qemu's genuine
+        # independent kernel with top-level AppArmor, and that nesting
+        # doesn't reliably support the fd-inheritance-across-confinement-
+        # transition semantics this check exercises - not a confinement
+        # regression in the snap, just an environment limitation. Skip
+        # cleanly inside any container, the same way tests/wayland skips
+        # when weston/pgtk aren't applicable.
         HAVE_YQ=0
-        if [ -x /snap/bin/yq ]; then
+        if systemd-detect-virt --container --quiet 2>/dev/null; then
+          echo "running inside a container ($(systemd-detect-virt --container)), skipping fd-inheritance check"
+        elif [ -x /snap/bin/yq ]; then
           HAVE_YQ=1
           echo 'foo: bar' > /tmp/emacs-snap-fd-test.yml
           FD_RESULT=$(emacs.emacsclient --eval '

--- a/tests/setup-env/task.yaml
+++ b/tests/setup-env/task.yaml
@@ -12,6 +12,46 @@ prepare: |
   # - if the store is unreachable, that check just skips cleanly
   snap install yq || true
 
+  # Work around LP#1815869: snap-confine's own AppArmor profile has no way to
+  # delegate an inherited file descriptor's permission check to the eventual
+  # per-app profile, so revalidating an inherited fd (eg a shell redirect
+  # like `yq < file.yml`) against snap-confine's own narrow profile can fail
+  # even for files the invoking user plainly owns. This is normally masked by
+  # the kernel's aa_file_perm() fast path for genuinely unconfined callers,
+  # but that fast path is skipped once a process has triggered Ubuntu's
+  # unprivileged_userns AppArmor profile stacking (eg via
+  # unshare(CLONE_NEWUSER)) - which every process inside an unprivileged LXD
+  # container has, inherited from the container's own init onward, which is
+  # why the lxd backend trips this and qemu's real VMs don't.
+  if [ "$SPREAD_BACKEND" = lxd ] && [[ "$SPREAD_SYSTEM" == ubuntu-* ]]; then
+    # Grant the same owner-scoped access snap-confine already carries for our
+    # test fixture's use of /tmp so inherited fds for files the invoking user
+    # owns are honoured consistently regardless of which fast path applies.
+    #
+    # Both the deb-packaged profile (confining /usr/lib/snapd/snap-confine) and
+    # the snapd-snap-bundled one (confining
+    # /snap/snapd/<rev>/usr/lib/snapd/snap-confine) #include a snapd-managed
+    # directory wholesale - any file dropped in there becomes part of the
+    # compiled profile automatically, the same way each one's existing "cap-bpf"
+    # file already does. That directory's name is snapd-version- specific and
+    # not safe to hardcode: it's "snap-confine" on snapd 2.76.3+ubuntu24.04, but
+    # was renamed to "snap-confine.internal" by snapd 2.76.3+ubuntu26.04 (both
+    # otherwise report the same "snap version" output, so the name alone doesn't
+    # tell you which one a given system uses) - so read the real #include target
+    # out of each profile source instead of guessing it.
+    for src in /etc/apparmor.d/usr.lib.snapd.snap-confine.real /var/lib/snapd/apparmor/profiles/snap-confine.snapd.*; do
+      [ -f "$src" ] || continue
+      inc=$(sed -n 's/.*#include "\(\/var\/lib\/snapd\/apparmor\/[^"]*\)".*/\1/p' "$src" | head -1)
+      if [ -n "$inc" ] && [ -d "$inc" ]; then
+        printf 'owner /tmp/** rw,\n' > "$inc/zz-fd-inherit-workaround"
+      fi
+    done
+    # Restart both services which manage these profiles since which of the two
+    # profiles above is the one that actually matters isn't guaranteed to be the
+    # same on every system.
+    systemctl restart snapd.apparmor.service apparmor.service 2>/dev/null || true
+  fi
+
 restore: |
   if [ -f /usr/share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml.bak ]; then
     mv /usr/share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml.bak /usr/share/glib-2.0/schemas/org.gtk.Settings.FileChooser.gschema.xml
@@ -22,6 +62,18 @@ restore: |
   pkill -x emacs 2>/dev/null || true
   rm -f /tmp/emacs-apparmor.log /tmp/emacs-snap-fd-test.yml
   snap remove yq 2>/dev/null || true
+
+  # undo the LP#1815869 workaround from prepare - same dynamic #include
+  # discovery as prepare, since the target directory name is snapd-version-
+  # specific (see prepare for why)
+  for src in /etc/apparmor.d/usr.lib.snapd.snap-confine.real /var/lib/snapd/apparmor/profiles/snap-confine.snapd.*; do
+    [ -f "$src" ] || continue
+    inc=$(sed -n 's/.*#include "\(\/var\/lib\/snapd\/apparmor\/[^"]*\)".*/\1/p' "$src" | head -1)
+    if [ -n "$inc" ] && [ -f "$inc/zz-fd-inherit-workaround" ]; then
+      rm -f "$inc/zz-fd-inherit-workaround"
+    fi
+  done
+  systemctl restart snapd.apparmor.service apparmor.service 2>/dev/null || true
 
 execute: |
   ! test -d ~/snap/emacs/common/.cache/schemas
@@ -137,21 +189,8 @@ execute: |
         # unrelated host-installed yq (eg python's, via apt/pip) that would
         # silently pass this check without ever going through snap-confine
         # at all.
-        #
-        # Confirmed (2026-09-09) by running this exact task side-by-side on
-        # the same host under both backends: it fails identically under lxd
-        # but passes under qemu. lxd containers get a nested AppArmor
-        # namespace stacked on the host kernel's, unlike qemu's genuine
-        # independent kernel with top-level AppArmor, and that nesting
-        # doesn't reliably support the fd-inheritance-across-confinement-
-        # transition semantics this check exercises - not a confinement
-        # regression in the snap, just an environment limitation. Skip
-        # cleanly inside any container, the same way tests/wayland skips
-        # when weston/pgtk aren't applicable.
         HAVE_YQ=0
-        if systemd-detect-virt --container --quiet 2>/dev/null; then
-          echo "running inside a container ($(systemd-detect-virt --container)), skipping fd-inheritance check"
-        elif [ -x /snap/bin/yq ]; then
+        if [ -x /snap/bin/yq ]; then
           HAVE_YQ=1
           echo 'foo: bar' > /tmp/emacs-snap-fd-test.yml
           FD_RESULT=$(emacs.emacsclient --eval '

--- a/tests/wayland/task.yaml
+++ b/tests/wayland/task.yaml
@@ -5,16 +5,16 @@ prepare: |
   # cloud images with no fonts at all, which isn't representative of a real
   # desktop.
   #
-  # weston is confirmed packaged for all the ubuntu-* systems here, but not
-  # confirmed available for the centos-*/rockylinux-* (EL8) family - EPEL only
-  # clearly carries it from EPEL 9 onward. Rather than guess, try the install
-  # and let execute skip cleanly if the binary isn't there.
+  # weston is confirmed packaged for all the ubuntu-*/debian-* systems here,
+  # but not confirmed available for the centos-*/rocky-* (EL9) family - EPEL
+  # only clearly carries it from EPEL 9 onward. Rather than guess, try the
+  # install and let execute skip cleanly if the binary isn't there.
   case $SPREAD_SYSTEM in
-    centos-*|rockylinux-*)
+    centos-*|rocky-*)
       dnf install -y dejavu-sans-fonts
       dnf install -y weston || true
       ;;
-    ubuntu-*)
+    ubuntu-*|debian-*)
       apt install -y fonts-dejavu-core
       apt install -y weston || true
       ;;
@@ -74,7 +74,10 @@ execute: |
     cat /tmp/emacs-wayland.log
     FAILED=1
   else
-    WINDOW_SYSTEM=$(emacs.emacsclient --eval '(frame-parameter nil (quote window-system))' 2>&1)
+    # timeout: an emacsclient --eval with no reply (e.g. the Wayland frame
+    # never fully coming up) would otherwise hang until spread's own
+    # kill-timeout, wasting the rest of this task's budget.
+    WINDOW_SYSTEM=$(timeout 30 emacs.emacsclient --eval '(frame-parameter nil (quote window-system))' 2>&1)
     if [ "$WINDOW_SYSTEM" != pgtk ]; then
       echo "expected a native pgtk frame, got: $WINDOW_SYSTEM"
       FAILED=1


### PR DESCRIPTION
spread.yaml only ever defined a local-only qemu backend that
needed manually-baked images - CI built the snap but never ran the
spread test suite against it. This adds a spread job to CI, backed by
a new image-garden-based backend that spread.yaml now uses for both
local dev and CI alike: real QEMU/KVM VMs, downloaded and cached
automatically, with no manual image-baking step.

**Changes**

- `spread.yaml`: replace the `qemu` backend with a `garden` backend
  (image-garden), covering 9 systems - Ubuntu 18.04-26.04, CentOS
  Stream 9, Rocky 9, and Debian 12/13 (added per real install-base
  usage data; CentOS/Rocky move from the no-longer-offered 8 stream to
  9). Retry the store-channel `snap install` a few times to absorb
  transient store-communication errors.
- `.github/workflows/main.yml`: add a `spread` job, run via
  `zyga/image-garden-action`, one matrix entry per system. The matrix
  is read dynamically out of `spread.yaml`
  (`backends.garden.systems`) rather than duplicated in the workflow,
  so the two can't drift apart. Scoped to the `local` channel (installs
  the snap just built by the `build` job, not one from the store).
- `.image-garden.mk`: add a placeholder file required to exist by
  `zyga/image-garden-action`'s own cache/mtime bookkeeping (we need no
  project-specific image-garden customization otherwise).
- `.gitignore`: ignore image-garden's generated VM images/state and
  spread's own resume bookkeeping, left behind by local `spread
  garden:...` runs.
- `tests/host-libraries/task.yaml`, `tests/wayland/task.yaml`: match
  `rocky-cloud-9` (was `rockylinux-*`, stale after the CentOS/Rocky 9
  rename above) and add `debian-*` alongside `ubuntu-*` for apt-based
  setup. Add a timeout around `tests/wayland`'s `emacsclient --eval`
  call, so a Wayland frame that never comes up fails fast instead of
  hanging until spread's `kill-timeout`.

**Testing**

Validated locally across all 9 systems in `spread.yaml` via `spread
garden:<system>:tests/`, covering both the `local` channel and
store-based channels (`latest`/`pgtk`/`lucid` tracks). Also validated
the CI workflow itself against a live run
(https://github.com/alexmurray/emacs-snap/actions/runs/34549640601).